### PR TITLE
Add php gd and swoole/octane support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,4 +4,7 @@ vendor
 .github/workflows
 bootstrap/cache/*
 public/build
+storage/clockwork/*
+storage/framework/*/*
+storage/logs/*
 openapi.yml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,6 @@
 .git
 node_modules
 vendor
-.github/workflows
 bootstrap/cache/*
 public/build
 storage/clockwork/*

--- a/.env.example
+++ b/.env.example
@@ -74,12 +74,14 @@ IDENTITY_STAFF_SECRET=
 #WWWUSER=1000
 #WWWGROUP=1000
 #WWWUSERNAME=sail
+
 ## default command to run dev server
 #DEV_SERVER_COMMAND="php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ## you can noop it with
-#DEV_SERVER_COMMAND="fail -F /dev/null"
-## if your dev server is handling requests slow, you can run a octane server instead (does not work for now)
+#DEV_SERVER_COMMAND="tail -F /dev/null"
+## if your dev server is handling requests slow, you can run a octane server instead
 #DEV_SERVER_COMMAND="php artisan octane:start --host=0.0.0.0 --port=80 --watch"
+
 ## admin password. used once on database seeding phase
 ADMIN_PASSWORD=admin
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
 
   laravel.test:
     # bump version if you change infra/dev/image/Containerfile
-    image: localhost/ef-identity-dev:v1
+    image: localhost/ef-identity-dev:v2
     build:
       context: ./infra/dev/image
       dockerfile: Containerfile

--- a/infra/dev/image/Containerfile
+++ b/infra/dev/image/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
 
 #
 # bump laravel.test image name version on every change of this file
@@ -17,7 +17,7 @@ WORKDIR /var/www/html
 ARG PHP_VERSION=8.2
 
 # list of all PHP packages to be installed
-ARG PHP_PACKAGES="php-cli composer php-intl php-json php-mbstring php-mysqlnd php-opcache php-pdo php-redis php-xml php-zip php-sodium php-bcmath"
+ARG PHP_PACKAGES="php-cli composer php-intl php-json php-mbstring php-mysqlnd php-opcache php-pdo php-gd php-redis php-xml php-swoole php-zip php-sodium php-bcmath"
 
 # nodels version to be installed
 ARG NODE_VERSION=20
@@ -26,7 +26,7 @@ ENV TZ=UTC
 
 RUN set -xe; \
     echo "==> Installing basic dependencies"; \
-    microdnf install -y --nodocs vim nano git wget sudo; \
+    microdnf install -y --nodocs vim nano git wget procps-ng sudo; \
     microdnf reinstall tzdata -y; \
     \
     echo "==> Setting up RPM repositories"; \
@@ -34,6 +34,10 @@ RUN set -xe; \
       rpm -i epel-release.rpm; rm epel-release.rpm; \
     wget -q https://rpms.remirepo.net/enterprise/remi-release-9.rpm -O remi-release.rpm; \
       rpm -i remi-release.rpm; rm remi-release.rpm; \
+    \
+    echo "==> Installing c-ares (swoole requirement) from compatible repository"; \
+    wget -q "https://mirror.stream.centos.org/9-stream/BaseOS/$(uname -m)/os/Packages/c-ares-1.17.1-4.el9.$(uname -m).rpm" -O c-ares.rpm; \
+      rpm -i --nodigest c-ares.rpm; rm c-ares.rpm; \
     \
     echo "==> Installing PHP $PHP_VERSION and extensions"; \
     microdnf module enable --nodocs -y php:remi-$PHP_VERSION; \
@@ -55,4 +59,4 @@ RUN set -xe; \
 COPY ./entrypoint.sh /entrypoint.sh
 COPY php.ini /etc/php.d/99_app.ini
 
-ENTRYPOINT exec /bin/bash /entrypoint.sh
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/infra/dev/image/Containerfile
+++ b/infra/dev/image/Containerfile
@@ -6,7 +6,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
 
 LABEL maintainer="ThunderAl <community@thunderal.net>" \
       org.opencontainers.image.authors="ThunderAl <community@thunderal.net>" \
-      org.opencontainers.image.title="EF Laraavel development environment" \
+      org.opencontainers.image.title="EF Laravel development environment" \
       org.opencontainers.image.description="Fine tuned for build time and size image for EF identity system with laravel sail support"
 
 WORKDIR /var/www/html
@@ -19,7 +19,7 @@ ARG PHP_VERSION=8.2
 # list of all PHP packages to be installed
 ARG PHP_PACKAGES="php-cli composer php-intl php-json php-mbstring php-mysqlnd php-opcache php-pdo php-gd php-redis php-xml php-swoole php-zip php-sodium php-bcmath"
 
-# nodels version to be installed
+# nodejs version to be installed
 ARG NODE_VERSION=20
 
 ENV TZ=UTC

--- a/infra/dev/image/README.md
+++ b/infra/dev/image/README.md
@@ -1,0 +1,41 @@
+# Identity Development Image
+
+This image is used to run the Identity development environment with docker-compose/sail.
+
+This image does not contain the full application.
+You need to mount sources by mounting root of the project to `/var/www/html` in the container.
+
+## Container Debugging
+
+There are commands to manually build and run the image for debugging purposes.
+
+### Manual Build
+
+Run this command at the root of the repository to build the image:
+
+```bash
+docker build -t localhost/ef-identity-dev:latest -f ./infra/dev/image/Containerfile ./infra/dev/image
+```
+
+### Manual Run
+
+You can run the entrypoint via:
+
+```bash
+docker run --rm -it -v "$(pwd):/var/www/html" -p 80:80 localhost/ef-identity-dev:latest
+```
+
+NOTE: `Ctrl+C` here will not stop the server, instead it will restart it. Hit `Ctrl+C` twice to stop the server.
+
+NOTE: If you are using Windows+msys2+docker/podman, you may need to run `export MSYS_NO_PATHCONV=1`
+to avoid path conversion issues with `$(pwd)`.
+
+Or run bash shell:
+
+```bash
+# runs bash shell as "sail" user
+docker run --rm -it -v "$(pwd):/var/www/html" localhost/ef-identity-dev:latest bash
+
+# runs bash shell as "root" user
+docker run --rm -it -v "$(pwd):/var/www/html" -e "WWWUSERNAME=root" localhost/ef-identity-dev:latest bash
+```

--- a/infra/release/image/Containerfile
+++ b/infra/release/image/Containerfile
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6 AS php-base
 
 LABEL maintainer="ThunderAl <community@thunderal.net>" \
       org.opencontainers.image.authors="ThunderAl <community@thunderal.net>" \
-      org.opencontainers.image.title="EF Laraavel release environment" \
+      org.opencontainers.image.title="EF Laravel release environment" \
       org.opencontainers.image.description="Fine tuned for build time and size image for EF identity system with laravel sail support"
 
 WORKDIR /var/www/html
@@ -15,7 +15,7 @@ ARG PHP_VERSION=8.2
 # list of all PHP packages to be installed
 ARG PHP_PACKAGES="php-cli composer php-intl php-json php-mbstring php-mysqlnd php-opcache php-pdo php-gd php-redis php-xml php-swoole php-zip php-sodium php-bcmath"
 
-# nodels version to be installed
+# nodejs version to be installed
 ARG NODE_VERSION=20
 
 ENV TZ=UTC

--- a/infra/release/image/Containerfile
+++ b/infra/release/image/Containerfile
@@ -1,12 +1,8 @@
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6
-
-#
-# bump laravel.test image name version on every change of this file
-#
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6 AS php-base
 
 LABEL maintainer="ThunderAl <community@thunderal.net>" \
       org.opencontainers.image.authors="ThunderAl <community@thunderal.net>" \
-      org.opencontainers.image.title="EF Laraavel development environment" \
+      org.opencontainers.image.title="EF Laraavel release environment" \
       org.opencontainers.image.description="Fine tuned for build time and size image for EF identity system with laravel sail support"
 
 WORKDIR /var/www/html
@@ -24,9 +20,13 @@ ARG NODE_VERSION=20
 
 ENV TZ=UTC
 
+#
+# Installing system dependencies
+#
+
 RUN set -xe; \
     echo "==> Installing basic dependencies"; \
-    microdnf install -y --nodocs vim nano git wget procps-ng sudo unzip; \
+    microdnf install -y --nodocs git wget procps-ng sudo unzip; \
     microdnf reinstall tzdata -y; \
     \
     echo "==> Setting up RPM repositories"; \
@@ -48,15 +48,60 @@ RUN set -xe; \
     microdnf module enable --nodocs -y nodejs:$NODE_VERSION; \
     microdnf install -y --nodocs nodejs npm; \
     \
-    microdnf clean all; \
-    \
-    echo "==> Setting up user (uid/gid will be changed by entrypoint later)"; \
-    groupadd --force -g 1000 sail; \
-    useradd -m -s /usr/bin/bash --no-user-group -g 1000 -u 1000 sail; \
-    wget -q https://github.com/tianon/gosu/releases/download/1.17/gosu-amd64 -O /usr/bin/gosu; \
-      chmod +x /usr/bin/gosu;
+    microdnf clean all;
 
-COPY ./entrypoint.sh /entrypoint.sh
-COPY php.ini /etc/php.d/99_app.ini
+COPY ./infra/release/image/entrypoint.sh /entrypoint.sh
+COPY ./infra/release/image/php.ini /etc/php.d/99_app.ini
+
+#
+# Pre-Download composer dependencies (post install scripts will be executed later)
+#
+
+COPY ./composer.json ./composer.lock /var/www/html/
+
+RUN --mount=type=cache,target=/root/.composer/cache \
+    set -xe; \
+    echo "==> Download composer dependencies"; \
+    composer install --no-dev --no-interaction --no-scripts;
+
+FROM php-base AS frontend
+
+#
+# dependencies as a separated layer
+#
+
+COPY ./package.json ./package-lock.json /var/www/html/
+
+RUN --mount=type=cache,target=/root/.npm \
+    set -xe; \
+    echo "==> Download frontend dependencies"; \
+    npm install --no-audit;
+
+#
+# build frontend assets
+#
+
+COPY . /var/www/html/
+COPY ./resources /var/www/html/resources
+
+RUN --mount=type=cache,target=/root/.npm \
+    set -xe; \
+    echo "==> Building frontend assets"; \
+    npm run build;
+
+FROM php-base AS release
+
+COPY . /var/www/html/
+
+RUN --mount=type=cache,target=/root/.composer/cache \
+    set -xe; \
+    echo "==> Finalise and install dependencies"; \
+    composer install --no-dev --no-interaction --optimize-autoloader; \
+    echo "==> Building common caches"; \
+    php artisan event:cache; \
+    php artisan route:cache; \
+    php artisan view:cache;
+
+COPY --from=frontend /var/www/html/public /var/www/html/public
 
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/infra/release/image/README.md
+++ b/infra/release/image/README.md
@@ -1,0 +1,13 @@
+# Identity Release Image
+
+This image is used to run the Identity application in production.
+
+This image contains the Identity application and all its dependencies.
+
+## Building the Image
+
+Run this command at the root of the repository to build the image:
+
+```bash
+docker build -t localhost/ef-identity-release:latest -f ./infra/release/image/Containerfile --target release .
+```

--- a/infra/release/image/entrypoint.sh
+++ b/infra/release/image/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+if [ ! -d "/var/www/html/vendor" ]; then
+    echo "Composer dependencies not installed. The image is not built properly."
+    exit 1
+fi
+
+if [ ! -f "/var/www/html/public/build/manifest.json" ]; then
+    echo "Assets not built. The image is not built properly."
+    exit 1
+fi
+
+# instantly exit with same code if any command fails
+set -e
+
+if [ $# -gt 0 ]; then
+    # if the command is set, we will run it
+    exec "$@"
+else
+    # starting the default octane command
+    exec php artisan octane:start --host=0.0.0.0 --port=80 --no-interaction
+fi

--- a/infra/release/image/php.ini
+++ b/infra/release/image/php.ini
@@ -1,0 +1,17 @@
+[global]
+upload_max_filesize = 100M
+post_max_size = 100M
+memory_limit = 256M
+variables_order = "EGPCS"
+
+[opcache]
+opcache.enable = 1
+; 0 means it will check on every request
+; 0 is irrelevant if opcache.validate_timestamps=0 which is desirable in production
+opcache.revalidate_freq = 0
+opcache.validate_timestamps = 1
+opcache.max_accelerated_files = 10000
+opcache.memory_consumption = 192
+opcache.max_wasted_percentage = 10
+opcache.interned_strings_buffer = 16
+opcache.fast_shutdown = 1

--- a/infra/release/image/php.ini
+++ b/infra/release/image/php.ini
@@ -9,7 +9,7 @@ opcache.enable = 1
 ; 0 means it will check on every request
 ; 0 is irrelevant if opcache.validate_timestamps=0 which is desirable in production
 opcache.revalidate_freq = 0
-opcache.validate_timestamps = 1
+opcache.validate_timestamps = 0
 opcache.max_accelerated_files = 10000
 opcache.memory_consumption = 192
 opcache.max_wasted_percentage = 10

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,0 @@
-{
-    "/js/app.js": "/js/app.js",
-    "/css/app.css": "/css/app.css"
-}


### PR DESCRIPTION
Closes #131 

* Updated ubi 9.5 -> 9.6
* Added php-gd ext
* Added libcares, swoole for octane
* Removed old mix-manifest.json file
* Added new production OCI image
  * uses same base image. `dev environment ~= prod environment`
  * builds faster, uses layer and fs caches and, generally, builds faster
  * **need to be tested in real k8s environment**