### PR TITLE
Fix Yubikey OTP being case sensitive

### DIFF
--- a/app/Http/Controllers/Profile/Settings/TwoFactor/YubikeySetupController.php
+++ b/app/Http/Controllers/Profile/Settings/TwoFactor/YubikeySetupController.php
@@ -40,10 +40,14 @@ class YubikeySetupController extends Controller
         }
         RateLimiter::hit($limitKey, 120);
         $yubico = new YubicoService();
-        $yubico->verify($request->input('code'));
+        $otp = strtolower($request->input('code'));
+        $yubico->verify($otp);
 
         // Check if the Yubikey is already registered
-        if ($request->user()->twoFactors()->where('identifier', $yubico->identifier)->exists()) {
+        $already_exists = $request->user()->twoFactors()
+            ->whereRaw('LOWER(identifier) = ?', [$yubico->identifier])
+            ->exists();
+        if ($already_exists) {
             throw ValidationException::withMessages(['code' => 'This Yubikey is already registered.']);
         }
         // Create the Yubikey

--- a/app/Http/Controllers/TwoFactorController.php
+++ b/app/Http/Controllers/TwoFactorController.php
@@ -76,7 +76,7 @@ class TwoFactorController extends Controller
         // Get the first 12 characters of the code
         $identifier = strtolower(substr($data['code'], 0, 12));
         // Find the identifier in $collection
-        $twoFactor = $twoFactors->firstWhere(fn($factor) => strtolower($factor->identifier) === $identifier);
+        $twoFactor = $twoFactors->firstWhere(fn ($factor) => strtolower($factor->identifier) === $identifier);
         if ($twoFactor === null) {
             throw ValidationException::withMessages(['code' => 'This Yubikey is not known.']);
         }

--- a/app/Http/Controllers/TwoFactorController.php
+++ b/app/Http/Controllers/TwoFactorController.php
@@ -74,9 +74,9 @@ class TwoFactorController extends Controller
     public function verifyYubikey($data, Collection $twoFactors, $user): bool
     {
         // Get the first 12 characters of the code
-        $identifier = substr($data['code'], 0, 12);
+        $identifier = strtolower(substr($data['code'], 0, 12));
         // Find the identifier in $collection
-        $twoFactor = $twoFactors->firstWhere('identifier', $identifier);
+        $twoFactor = $twoFactors->firstWhere(fn($factor) => strtolower($factor->identifier) === $identifier);
         if ($twoFactor === null) {
             throw ValidationException::withMessages(['code' => 'This Yubikey is not known.']);
         }

--- a/app/Services/YubicoService.php
+++ b/app/Services/YubicoService.php
@@ -13,6 +13,7 @@ class YubicoService
 
     public function verify(string $otp): bool
     {
+        $otp = strtolower($otp);
         $this->nonce = bin2hex(random_bytes(16));
 
         $requestParams = [
@@ -48,7 +49,7 @@ class YubicoService
             throw ValidationException::withMessages(['code' => $errorMessage]);
         }
         // Get the first 12 characters of the OTP
-        $this->identifier = substr($responseData['otp'], 0, 12);
+        $this->identifier = strtolower(substr($responseData['otp'], 0, 12));
 
         return true;
     }


### PR DESCRIPTION
Fixes issues where if someone were to accidentally capitalize the OTP identifier, it could cause users to not log in in cases where the OTP identifier doesnt match whats in the database

Some of the changes can be removed if a database migration was made to make the existing identifiers lowercase if the type is yubikey.